### PR TITLE
implement articles, add breakpoint constants, clean up code

### DIFF
--- a/src/components/colorblock/colorblock.js
+++ b/src/components/colorblock/colorblock.js
@@ -8,18 +8,21 @@ import {
   OneColumn,
   Content,
   ButtonText,
-  RelativeContainer,
+  AbsoluteContainer,
+  Container,
 } from "./styled";
 
 const ColorBlock = ({ content, color }) => {
   const buttonContent = content.callToAction.fields;
   return (
     <ColorSection color={color}>
-      <RelativeContainer>
-        <Header>
-          <H1>{content.heading}</H1>
-        </Header>
-      </RelativeContainer>
+      <Container>
+        <AbsoluteContainer>
+          <Header>
+            <H1>{content.heading}</H1>
+          </Header>
+        </AbsoluteContainer>
+      </Container>
       <Content>
         <OneColumn>
           <P1>{content.description}</P1>

--- a/src/components/colorblock/styled.js
+++ b/src/components/colorblock/styled.js
@@ -1,37 +1,43 @@
 import styled from "styled-components";
+import { MIN_MOBILE_SIZE } from "../../constants/constants";
 
-export const ColorSection = styled.div.attrs({className: 'container-fluid my-5'})`
-    background-color: ${props => props.color};
-    padding-bottom: 5rem !important;
-`
+export const ColorSection = styled.div.attrs({
+  className: "container-fluid my-5 py-5",
+})`
+  background-color: ${(props) => props.color};
+`;
 
-export const TwoColumn = styled.div.attrs({className: 'd-none d-sm-block col-11 col-md-10 col-lg-8 col-xl-8'})`
-    column-count: 2;
-    column-gap: 50px;
-`
+export const TwoColumn = styled.div.attrs({
+  className: "d-none d-sm-block col-11 col-md-10 col-lg-8 col-xl-8",
+})`
+  column-count: 2;
+  column-gap: 50px;
+`;
 
-export const OneColumn = styled.div.attrs({className: "d-block d-sm-none d-col-12"})`
-`
+export const OneColumn = styled.div.attrs({
+  className: "d-block d-sm-none d-col-12",
+})``;
 
-export const RelativeContainer = styled.div.attrs({className: 'container'})`
-    position: relative;
-`
+export const AbsoluteContainer = styled.div`
+  position: absolute;
+`;
 
-export const Header = styled.div.attrs({className: "col-10 col-md-8 col-lg-6 col-xl-4"})`
-    position: absolute;
-    top: -108px;
-    padding: 0;
+export const Header = styled.div`
+  position: relative;
+  top: -100px;
 
-    @media (min-width: 576px) {
+  padding: 0;
+
+  @media (min-width: ${MIN_MOBILE_SIZE}) {
     padding: 0 15px;
-    }
-`
+  }
+`;
 
-export const Content = styled.div.attrs({className: 'container'})`
-    margin-top: -20px;
-`
+export const Content = styled.div.attrs({ className: "container mt-5" })``;
 
 export const ButtonText = styled.div`
-    margin: 0;
-    padding: 15px 25px;
-`
+  margin: 0;
+  padding: 15px 25px;
+`;
+
+export const Container = styled.div.attrs({ className: "container" })``;

--- a/src/components/hero/homepage-hero/hpHero.js
+++ b/src/components/hero/homepage-hero/hpHero.js
@@ -1,17 +1,17 @@
-import { Link } from "gatsby";
 import React from "react";
-import { H1, P1, P2, SecondaryLink } from "../styles/styles";
+import SecondaryLink from "../../secondary_link/secondaryLink";
+import { H1, P1 } from "../../styles/styles";
 import {
   HeroBlockOverlay,
   HeroImage,
   HeroImageContainer,
   HeroBlockPosition,
   HpHeroContainer,
-  Container
+  Container,
 } from "./styled";
 
 const HpHero = ({ content }) => {
-    const buttonContent = content.ctaButton
+  const buttonContent = content.ctaButton;
   return (
     <HpHeroContainer>
       <HeroImageContainer>
@@ -22,7 +22,14 @@ const HpHero = ({ content }) => {
           <HeroBlockOverlay>
             <H1>{content.heading}</H1>
             <P1>{content.description}</P1>
-            {buttonContent && <Link to={buttonContent.buttonLink}><SecondaryLink>{buttonContent.label} &#62;</SecondaryLink></Link>}
+            {buttonContent && (
+              <SecondaryLink
+                content={{
+                  url: buttonContent.buttonLink,
+                  label: buttonContent.label,
+                }}
+              />
+            )}
           </HeroBlockOverlay>
         </HeroBlockPosition>
       </Container>

--- a/src/components/hero/homepage-hero/styled.js
+++ b/src/components/hero/homepage-hero/styled.js
@@ -1,6 +1,9 @@
 import styled from "styled-components";
-import { PRIMARY_YELLOW } from "../styles/styles";
-import { OVERLAY_ZINDEX } from "../../constants/constants";
+import {
+  MIN_LG_DESKTOP_SIZE,
+  OVERLAY_ZINDEX,
+} from "../../../constants/constants";
+import { PRIMARY_YELLOW } from "../../styles/styles";
 
 export const HpHeroContainer = styled.div.attrs({
   classname: "d-flex flex-column",
@@ -21,7 +24,7 @@ export const HeroImageContainer = styled.div.attrs({
 })`
   height: 70vh;
 
-  @media (min-width: 1550px) {
+  @media (min-width: ${MIN_LG_DESKTOP_SIZE}) {
     height: 60vh;
   }
 `;
@@ -36,7 +39,7 @@ export const HeroBlockOverlay = styled.div.attrs({
   overflow: hidden;
   bottom: 40vh;
 
-  @media (min-width: 1550px) {
+  @media (min-width: ${MIN_LG_DESKTOP_SIZE}) {
     top: -35vh;
   }
 `;

--- a/src/components/hero/whoWeAre/styled.js
+++ b/src/components/hero/whoWeAre/styled.js
@@ -1,20 +1,26 @@
-import styled from 'styled-components'
-import { PRIMARY_YELLOW } from "../../styles/styles"
+import styled from "styled-components";
+import {
+  MIN_LG_DESKTOP_SIZE,
+  MIN_MOBILE_SIZE,
+  MIN_SM_DESKTOP_SIZE,
+  MIN_TABLET_SIZE,
+} from "../../../constants/constants";
+import { PRIMARY_YELLOW } from "../../styles/styles";
 
 export const ColorBlock = styled.div`
   background-color: ${PRIMARY_YELLOW};
   position: relative;
-`
+`;
 
 export const Container = styled.div`
   padding: 15px 0;
   position: relative;
 
-  @media (min-width: 576px) {
+  @media (min-width: ${MIN_MOBILE_SIZE}) {
     padding: 55px 0;
   }
 
-  @media (min-width: 992px) {
+  @media (min-width: ${MIN_SM_DESKTOP_SIZE}) {
     max-width: 960px;
     margin: 0 auto;
   }
@@ -22,14 +28,16 @@ export const Container = styled.div`
   @media (min-width: 1200px) {
     max-width: 1140px;
   }
-`
+`;
 
-export const ContentContainer = styled.div.attrs({ className: "col-md-6 col-lg-5", })``
+export const ContentContainer = styled.div.attrs({
+  className: "col-md-6 col-lg-5",
+})``;
 
 export const SideImage = styled.img`
   display: none;
 
-  @media (min-width: 768px) {
+  @media (min-width: ${MIN_TABLET_SIZE}) {
     display: block;
   }
 
@@ -41,14 +49,14 @@ export const SideImage = styled.img`
   right: 0;
   bottom: -75px;
 
-  @media (min-width: 1550px) {
+  @media (min-width: ${MIN_LG_DESKTOP_SIZE}) {
     display: none;
   }
-`
+`;
 
 export const XLImage = styled.img`
   display: none;
-  @media (min-width: 1550px) {
+  @media (min-width: ${MIN_LG_DESKTOP_SIZE}) {
     display: block;
     margin-bottom: 0;
     width: 50%;
@@ -58,7 +66,8 @@ export const XLImage = styled.img`
     right: 0;
     bottom: -75px;
   }
-`
+`;
 
-export const FullBleedImage = styled.img.attrs({ className: 'd-md-none' })`
-  margin-bottom: 0;`
+export const FullBleedImage = styled.img.attrs({ className: "d-md-none" })`
+  margin-bottom: 0;
+`;

--- a/src/components/image_info_section/styled.js
+++ b/src/components/image_info_section/styled.js
@@ -1,9 +1,10 @@
 import styled from 'styled-components'
+import { MIN_SM_DESKTOP_SIZE } from '../../constants/constants'
 
 export const Container = styled.div.attrs({ className: "d-flex flex-wrap align-items-center" })`
   padding: 5em 0;
 
-  @media (min-width: 992px) {
+  @media (min-width: ${MIN_SM_DESKTOP_SIZE}) {
     max-width: 960px;
     margin: 0 auto;
   }

--- a/src/components/mission/missionStatement.js
+++ b/src/components/mission/missionStatement.js
@@ -4,34 +4,37 @@ import {
   BleedBreakPoint,
   Content,
   Description,
-  ImageWrapper
+  ImageWrapper,
+  ContentDescription,
+  Container,
+  FlexWrapper,
 } from "./styled";
 
 const MissionStatement = ({ content }) => {
   return (
     <>
-    <div className="d-flex flex-column my-5">
-      <div className="container">
-        <H2>Our Vision</H2>
-        <H1>{content.statement}</H1>
-        <Description className="d-block d-md-none">
-          <P1>{content.description}</P1>
-        </Description>
-      </div>
-      <BleedBreakPoint>
-        <Content>
-          <Description className="col-xl-5 mr-4">
+      <FlexWrapper>
+        <Container>
+          <H2>Our Vision</H2>
+          <H1>{content.statement}</H1>
+          <Description className="d-block d-md-none">
             <P1>{content.description}</P1>
           </Description>
-          <ImageWrapper className="col-xl-7">
-            <img alt={content.imageSrc.fileName} src={content.imageSrc.url} />
-          </ImageWrapper>
-        </Content>
-      </BleedBreakPoint>
-      <ImageWrapper className="d-block d-md-none  mb-5 align-self-end">
-        <img alt={content.imageSrc.fileName} src={content.imageSrc.url} />
-      </ImageWrapper>
-      </div>
+        </Container>
+        <BleedBreakPoint>
+          <Content>
+            <Description className="col-xl-5">
+              <ContentDescription>{content.description}</ContentDescription>
+            </Description>
+            <ImageWrapper className="col-xl-7">
+              <img alt={content.imageSrc.fileName} src={content.imageSrc.url} />
+            </ImageWrapper>
+          </Content>
+        </BleedBreakPoint>
+        <ImageWrapper className="d-block d-md-none mb-5 align-self-end">
+          <img alt={content.imageSrc.fileName} src={content.imageSrc.url} />
+        </ImageWrapper>
+      </FlexWrapper>
     </>
   );
 };

--- a/src/components/mission/styled.js
+++ b/src/components/mission/styled.js
@@ -1,11 +1,16 @@
 import styled from "styled-components";
+import {
+  MIN_LG_DESKTOP_SIZE,
+  MIN_TABLET_SIZE,
+} from "../../constants/constants";
+import { P1 } from "../styles/styles";
 
 export const ImageWrapper = styled.div.attrs({ className: "mb-5" })`
   float: right;
   padding: 0 !important;
   width: 80vw;
 
-  @media (min-width: 768px) {
+  @media (min-width: ${MIN_TABLET_SIZE}) {
     width: 60vw;
   }
 
@@ -15,21 +20,19 @@ export const ImageWrapper = styled.div.attrs({ className: "mb-5" })`
 `;
 
 export const Description = styled.div.attrs({
-  className: "col-12 col-md-6 col-lg-4",
+  className: "col-12 col-md-6 col-lg-4 mb-3",
 })`
-  padding: 0 !important;
-
-  @media (min-width: 768px) {
+  @media (min-width: ${MIN_TABLET_SIZE}) {
     padding-left: 11.5vw !important;
   }
 
-  @media (min-width: 1550px) {
+  @media (min-width: ${MIN_LG_DESKTOP_SIZE}) {
     padding-left: 0 !important;
   }
 `;
 
 export const BleedBreakPoint = styled.div`
-  @media (min-width: 1550px) {
+  @media (min-width: ${MIN_LG_DESKTOP_SIZE}) {
     max-width: 1140px;
     width: 100%;
     padding-right: 15px;
@@ -44,10 +47,18 @@ export const Content = styled.div.attrs({
 })`
   justify-content: space-between;
 
-  @media (min-width: 1550px) {
+  @media (min-width: ${MIN_LG_DESKTOP_SIZE}) {
     max-width: 1140px;
     width: 100%;
     margin-right: auto !important;
     margin-left: auto !important;
   }
 `;
+
+export const ContentDescription = styled(P1).attrs({ className: "pr-3" })``;
+
+export const Container = styled.div.attrs({ className: "container" })``;
+
+export const FlexWrapper = styled.div.attrs({
+  className: "d-flex flex-column my-5",
+})``;

--- a/src/components/nav/hamburger/styled.js
+++ b/src/components/nav/hamburger/styled.js
@@ -1,6 +1,6 @@
 import { Link } from "gatsby";
 import styled from "styled-components";
-import { MAX_ZINDEX } from "../../../constants/constants";
+import { MAX_ZINDEX, MIN_SM_DESKTOP_SIZE, MIN_TABLET_SIZE } from "../../../constants/constants";
 import {
   BG_WHITE,
   H1,
@@ -49,10 +49,10 @@ export const MenuContainer = styled.div`
   @media (min-width: 0px) {
     padding-left: 0;
   }
-  @media (min-width: 768px) {
+  @media (min-width: ${MIN_TABLET_SIZE}) {
     padding-left: 0;
   }
-  @media (min-width: 992px) {
+  @media (min-width: ${MIN_SM_DESKTOP_SIZE}) {
     padding-left: 0;
   }
 `;
@@ -70,10 +70,10 @@ export const HambLinkContainer = styled.div`
   @media (min-width: 0px) {
     padding-left: 30px;
   }
-  @media (min-width: 768px) {
+  @media (min-width: ${MIN_TABLET_SIZE}) {
     padding-left: 50px;
   }
-  @media (min-width: 992px) {
+  @media (min-width: ${MIN_SM_DESKTOP_SIZE}) {
     padding-left: 100px;
   }
   @media (min-width: 1200px) {

--- a/src/components/news/article/article.js
+++ b/src/components/news/article/article.js
@@ -1,0 +1,25 @@
+import React from "react";
+import SecondaryLink from "../../secondary_link/secondaryLink";
+import { H3 } from "../../styles/styles";
+import {
+  ArticleImage,
+  ImageContainer,
+  ArticleSummary,
+  SizeWrapper,
+} from "./styled";
+
+const Article = ({ content }) => {
+  const imageSrc = content.thumbnail.fields.file.url;
+  return (
+    <SizeWrapper className="col-8 col-md-3 p-0 mb-5">
+      <ImageContainer>
+        <ArticleImage image={imageSrc}></ArticleImage>
+      </ImageContainer>
+      <H3>{content.title}</H3>
+      <ArticleSummary>{content.summary}</ArticleSummary>
+      <SecondaryLink content={{ url: content.url, label: "Read More" }} />
+    </SizeWrapper>
+  );
+};
+
+export default Article;

--- a/src/components/news/article/styled.js
+++ b/src/components/news/article/styled.js
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+import { P1 } from "../../styles/styles";
+
+export const ArticleImage = styled.div`
+  background-image: ${(props) => (props.image ? `url(${props.image})` : null)};
+  height: 100%;
+  width: 100%;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: 50% 50%;
+`;
+
+export const ImageContainer = styled.div`
+  height: 350px;
+  margin-bottom: 25px;
+`;
+
+export const ArticleSummary = styled(P1).attrs({
+  className: "d-none d-lg-block",
+})``;
+
+export const SizeWrapper = styled.div.attrs({
+  className: "col-8 col-md-3 p-0 mb-5",
+})``;

--- a/src/components/news/news.js
+++ b/src/components/news/news.js
@@ -1,0 +1,20 @@
+import React from "react";
+import { H1, H2 } from "../styles/styles";
+import { Articles, NewsWrapper } from "./styled";
+import Article from "./article/article";
+
+const News = ({ content }) => {
+  return (
+    <NewsWrapper>
+      <H2>News</H2>
+      <H1>{content.heading}</H1>
+      <Articles>
+        {content.articles.map((article, i) => (
+          <Article key={i} content={article.fields} />
+        ))}
+      </Articles>
+    </NewsWrapper>
+  );
+};
+
+export default News;

--- a/src/components/news/styled.js
+++ b/src/components/news/styled.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+export const Articles = styled.div.attrs({
+  className: "col-11 p-0 d-block d-md-flex",
+})`
+  justify-content: space-between;
+`;
+
+export const NewsWrapper = styled.div.attrs({ className: "container my-5" })``;

--- a/src/components/secondary_link/secondaryLink.js
+++ b/src/components/secondary_link/secondaryLink.js
@@ -1,0 +1,30 @@
+import React from "react";
+import {
+  SecondaryLinkText,
+  LinkContainer,
+  ExternalLink,
+  InternalLink,
+  HighlightHover,
+} from "./styled";
+
+const SecondaryLink = ({ content }) => {
+  const isExternal = content.url ? content.url.includes("http") : null;
+  const text = content.label ? content.label : "Click here";
+  return (
+    <LinkContainer>
+      <HighlightHover>
+        {isExternal ? (
+          <ExternalLink href={content.url}>
+            <SecondaryLinkText>{text} &#62;</SecondaryLinkText>
+          </ExternalLink>
+        ) : (
+          <InternalLink to={content.url}>
+            <SecondaryLinkText>{text} &#62;</SecondaryLinkText>
+          </InternalLink>
+        )}
+      </HighlightHover>
+    </LinkContainer>
+  );
+};
+
+export default SecondaryLink;

--- a/src/components/secondary_link/styled.js
+++ b/src/components/secondary_link/styled.js
@@ -1,0 +1,48 @@
+import { Link } from 'gatsby';
+import styled from 'styled-components';
+import { P2, PRIMARY_YELLOW, TEXT_BLACK } from '../styles/styles';
+
+export const LinkContainer = styled.div.attrs({className: 'my-3'})`
+  display: flex;
+  position: relative;
+  width: max-content;
+  z-index: 1;
+`;
+
+export const HighlightHover = styled.div`
+  text-decoration: none;
+  color: ${TEXT_BLACK};
+
+  :hover {
+    ::after {
+      content: "";
+      display: inline-block;
+      bottom: 5%;
+      background-color: ${PRIMARY_YELLOW};
+      height: 40%;
+      width: 100%;
+      position: absolute;
+      z-index: -1;
+    }
+  }
+`;
+
+export const ExternalLink = styled.a`
+  :hover {
+    text-decoration: none;
+  }
+`
+export const InternalLink = styled(Link)`
+  :hover {
+    text-decoration: none;
+  }
+`
+
+export const SecondaryLinkText = styled(P2)`
+  text-decoration: none;
+  color: ${TEXT_BLACK};
+
+  :hover {
+    text-decoration: none;
+  }
+`;

--- a/src/components/secondary_nav/styled.js
+++ b/src/components/secondary_nav/styled.js
@@ -1,9 +1,10 @@
 import styled from 'styled-components'
 import { TEXT_BLACK, PRIMARY_YELLOW } from '../styles/styles'
 import { AnchorLink } from 'gatsby-plugin-anchor-links'
+import { MIN_SM_DESKTOP_SIZE } from '../../constants/constants'
 
 export const Container = styled.div`
-  @media (min-width: 992px) {
+  @media (min-width: ${MIN_SM_DESKTOP_SIZE}) {
     max-width: 960px;
     margin: 0 auto;
   }

--- a/src/components/styles/styles.js
+++ b/src/components/styles/styles.js
@@ -1,5 +1,5 @@
-import { Link } from "gatsby";
 import styled from "styled-components";
+import { MIN_SM_DESKTOP_SIZE } from "../../constants/constants";
 
 // Colors
 export const PRIMARY_YELLOW = "#FFD43D";
@@ -17,7 +17,7 @@ export const H1 = styled.h1`
   font-size: 36px;
   margin-bottom: 35px;
 
-  @media (min-width: 768px) {
+  @media (min-width: ${MIN_SM_DESKTOP_SIZE}) {
     font-size: 55px;
     margin-bottom: 55px;
   }
@@ -30,8 +30,17 @@ export const H2 = styled.h2`
   font-weight: 300;
   line-height: 31px;
 
-  @media (min-width: 768px) {
+  @media (min-width: ${MIN_SM_DESKTOP_SIZE}) {
     font-size: 22px;
+  }
+`;
+
+export const H3 = styled.h3`
+  font-family: "Work Sans", sans-serif;
+  font-size: 15px;
+
+  @media (min-width: ${MIN_SM_DESKTOP_SIZE}) {
+    font-size: 24px;
   }
 `;
 
@@ -42,12 +51,11 @@ export const P1 = styled.p`
   line-height: 32px;
   margin-bottom: 0;
 
-  @media (min-width:  768px) {
+  @media (min-width: ${MIN_SM_DESKTOP_SIZE}) {
     font-size: 16px;
     line-height: 30px;
   }
-  
-`
+`;
 
 export const P2 = styled.p`
   font-family: "IBM Plex Sans", sans-serif;
@@ -55,21 +63,10 @@ export const P2 = styled.p`
   font-weight: 600;
   margin: 0;
 
-  @media (min-width: 768px) {
+  @media (min-width: ${MIN_SM_DESKTOP_SIZE}) {
     font-size: 16px;
   }
 `;
-
-// Links
-export const SecondaryLink = styled(P2)`
-  text-decoration: none;
-  color: ${TEXT_BLACK};
-
-  :hover{ 
-    text-decoration: none;
-  }
-
-` 
 
 // Images
 export const RoundImage = styled.img`
@@ -81,15 +78,14 @@ export const Button = styled.button`
   border: 2px solid ${TEXT_BLACK};
   background-color: transparent;
   background-repeat: no-repeat;
-  color: ${props => console.log('this is color', props.color)};
 
   &:hover {
     background-color: ${TEXT_BLACK};
-    color: ${props => props.color ? PRIMARY_YELLOW : BG_WHITE};
+    color: ${(props) => (props.color ? PRIMARY_YELLOW : BG_WHITE)};
   }
 `;
 
 // background-color
 export const BackgroundColor = styled.div`
-  background-color: ${BG_WHITE}
-`
+  background-color: ${BG_WHITE};
+`;

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -1,12 +1,18 @@
 export const HOMEPAGE_ID = "homePage";
 export const WHOWEARE_ID = "whoWeArePage";
 export const WHATWEDO_ID = "whatWeDoPage";
-export const CONTACT_ID = "contactPage"
+export const CONTACT_ID = "contactPage";
 
-export const HOMEPAGE_LINK = "/"
-export const WHOWEARE_LINK = "/whoWeAre"
-export const WHATWEDO_LINK = "/whatWeDo"
-export const CONTACT_LINK = "/contact"
+export const HOMEPAGE_LINK = "/";
+export const WHOWEARE_LINK = "/whoWeAre";
+export const WHATWEDO_LINK = "/whatWeDo";
+export const CONTACT_LINK = "/contact";
 
-export const MAX_ZINDEX = 100000000000000
-export const OVERLAY_ZINDEX = 1000000
+export const MAX_ZINDEX = 100000000000000;
+export const OVERLAY_ZINDEX = 1000000;
+
+export const MIN_MOBILE_SIZE = "576px";
+export const MIN_TABLET_SIZE = "768px";
+export const MIN_SM_DESKTOP_SIZE = "992px";
+export const MIN_MD_DESKTOP_SIZE = "1200px";
+export const MIN_LG_DESKTOP_SIZE = "1550px";

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -7,7 +7,9 @@ import ColorBlock from "../components/colorblock/colorblock";
 import Testimonial from "../components/testimonial/testimonial";
 import { HOMEPAGE_ID } from "../constants/constants";
 import apiService from "../service/apiService";
-import HpHero from "../components/homepage-hero/hpHero";
+import News from "../components/news/news";
+import HpHero from "../components/hero/homepage-hero/hpHero";
+import ImageInfoSection from "../components/image_info_section/imageInfoSection";
 
 require("dotenv").config({
   path: `.env.${process.env.NODE_ENV}`,
@@ -22,27 +24,55 @@ const HomePage = () => {
       .then((response) => setPageContent(response[0].fields));
   }, []);
 
-  const missionContent = pageContent.missionStatementImage ? {
-    statement: pageContent.missionStatement,
-    description: pageContent.missionStatementDescription,
-    imageSrc: pageContent.missionStatementImage.fields.file
-  } : null
-  const heroContent = pageContent.heroImage ? {
-    heading: pageContent.heroHeading,
-    description: pageContent.description,
-    imageSrc: pageContent.heroImage.fields.file.url,
-    ctaButton: pageContent.homepageHeroCta.fields
-  } : null
-  const ColorBlockContent = pageContent.more ? pageContent.more.fields : null
-  const testimonialContent = pageContent.testimonial ? pageContent.testimonial.fields : null
-  console.log(pageContent)
+  const missionContent = pageContent.missionStatementImage
+    ? {
+        statement: pageContent.missionStatement,
+        description: pageContent.missionStatementDescription,
+        imageSrc: pageContent.missionStatementImage.fields.file,
+      }
+    : null;
+  const heroContent = pageContent.heroImage
+    ? {
+        heading: pageContent.heroHeading,
+        description: pageContent.description,
+        imageSrc: pageContent.heroImage.fields.file.url,
+        ctaButton: pageContent.homepageHeroCta.fields,
+      }
+    : null;
+  const colorBlockContent = pageContent.more ? pageContent.more.fields : null;
+  const newsContent =
+    pageContent.articles && pageContent.articles.length !== 0
+      ? {
+          heading: pageContent.newsHeading,
+          articles: pageContent.articles,
+        }
+      : null;
+  const testimonialContent = pageContent.testimonial
+    ? pageContent.testimonial.fields
+    : null;
+  const researchContent =
+    pageContent.research && pageContent.research.fields.images.length > 0
+      ? pageContent.research.fields
+      : null;
+  console.log(pageContent);
   return (
     <Layout>
       <SEO title="Home" />
-      {heroContent && (<HpHero content={heroContent}/>)}
-      {missionContent && (<MissionStatement content={missionContent} />)}
-      {ColorBlockContent && <ColorBlock content={ColorBlockContent} color={PRIMARY_YELLOW}/>}
+      {heroContent && <HpHero content={heroContent} />}
+      {missionContent && <MissionStatement content={missionContent} />}
+      {colorBlockContent && (
+        <ColorBlock content={colorBlockContent} color={PRIMARY_YELLOW} />
+      )}
+      {researchContent && (
+        <ImageInfoSection
+          id={pageContent.research.sys.id}
+          section="Research"
+          content={researchContent}
+          variant={false}
+        />
+      )}
       {testimonialContent && <Testimonial content={testimonialContent} />}
+      {newsContent && <News content={newsContent} />}
     </Layout>
   );
 };


### PR DESCRIPTION
in this pr:

- constants for breakpoints
- secondary cta styling (as a component. This takes in a url and a label. All styling is within the .styled for the secondary_link folder)
- included research section on homepage
- news section implementation
- fixed some styling issues on the colorblock
- updated the mobile font styles to also be shown on tablet screen sizes

articles/news section:

desktop:
<img width="636" alt="Screen Shot 2020-11-29 at 12 58 44 PM" src="https://user-images.githubusercontent.com/39138908/100556350-c21a1e80-3256-11eb-85f7-56ab62c8feec.png">


w/ hover:
<img width="1289" alt="Screen Shot 2020-11-29 at 12 59 03 PM" src="https://user-images.githubusercontent.com/39138908/100556358-ccd4b380-3256-11eb-8f3e-4f036a79e55c.png">


tablet:
<img width="768" alt="Screen Shot 2020-11-29 at 12 54 32 PM" src="https://user-images.githubusercontent.com/39138908/100556359-d100d100-3256-11eb-8e2f-5135d7684245.png">


mobile:
<img width="321" alt="Screen Shot 2020-11-29 at 12 54 49 PM" src="https://user-images.githubusercontent.com/39138908/100556365-d52cee80-3256-11eb-91e7-10f669aaae97.png">

